### PR TITLE
Tweak boot config handling

### DIFF
--- a/recipes/boards/x86.sh
+++ b/recipes/boards/x86.sh
@@ -27,7 +27,8 @@ VOLINITUPDATER=no # Temporary until the repo is fixed
 ## Partition info
 BOOT_START=1
 BOOT_END=512
-BOOT_TYPE=gpt        # msdos or gpt
+BOOT_TYPE=gpt # msdos or gpt
+BOOT_USE_UUID=yes
 INIT_TYPE="init.x86" # init.{x86/nextarm/nextarm_tvbox}
 
 # Modules that will be added to intramfs
@@ -146,9 +147,9 @@ device_chroot_tweaks_pre() {
 
   log "Preparing BIOS" "info"
 
-  log "Installing Syslinux Legacy BIOS"
+  log "Installing Syslinux Legacy BIOS at ${BOOT_PART-?BOOT_PART is not known}"
   syslinux -v
-  syslinux "${BOOT_PART-?BOOT_PART is not known}"
+  syslinux "${BOOT_PART}"
 
   log "Preparing boot configurations" "info"
 
@@ -221,11 +222,8 @@ device_chroot_tweaks_pre() {
 
   log "Finished setting up boot config" "okay"
 
-  log "Copying fstab as a template to be used in initrd"
-  cp /etc/fstab /etc/fstab.tmpl
-
-  log "Editing fstab to use UUID=<uuid of boot partition>"
-  sed -i "s/%%BOOTPART%%/UUID=${UUID_BOOT}/g" /etc/fstab
+  log "Creating fstab template to be used in initrd"
+  sed -i "s/UUID=${UUID_BOOT}/%%BOOTPART%%/g" /etc/fstab >/etc/fstab.tmpl
 
   log "Setting plymouth theme to volumio"
   plymouth-set-default-theme volumio

--- a/recipes/boards/x86.sh
+++ b/recipes/boards/x86.sh
@@ -82,19 +82,22 @@ write_device_files() {
   cp volumio/bin/volumio_hda_intel_tweak.sh "${ROOTFSMNT}"/usr/local/bin/volumio_hda_intel_tweak.sh
   chmod +x "${ROOTFSMNT}"/usr/local/bin/volumio_hda_intel_tweak.sh
 
+  log "Creating efi folders"
+  mkdir -p "${ROOTFSMNT}"/boot/efi
+  mkdir -p "${ROOTFSMNT}"/boot/efi/EFI/debian
+  mkdir -p "${ROOTFSMNT}"/boot/efi/BOOT/
+  log "Copying bootloaders and grub configuration template"
+  mkdir -p "${ROOTFSMNT}"/boot/grub
+  cp "${pkg_root}"/efi/BOOT/grub.cfg "${ROOTFSMNT}"/boot/efi/BOOT/grub.tmpl
+  cp "${pkg_root}"/efi/BOOT/BOOTIA32.EFI "${ROOTFSMNT}"/boot/efi/BOOT/BOOTIA32.EFI
+  cp "${pkg_root}"/efi/BOOT/BOOTX64.EFI "${ROOTFSMNT}"/boot/efi/BOOT/BOOTX64.EFI
+
 }
 
 write_device_bootloader() {
   log "Running write_device_bootloader" "ext"
   log "Copying the Syslinux boot sector"
   dd conv=notrunc bs=440 count=1 if="${ROOTFSMNT}"/usr/lib/syslinux/mbr/gptmbr.bin of="${LOOP_DEV}"
-
-  log "Creating efi folders"
-  mkdir -p "${ROOTFSMNT}"/boot/efi
-  mkdir -p "${ROOTFSMNT}"/boot/efi/EFI/debian
-  mkdir -p "${ROOTFSMNT}"/boot/efi/BOOT/
-  log "Copying bootloaders and grub configuration template"
-  cp -R "${pkg_root}"/efi/* "${ROOTFSMNT}"/boot/efi
 }
 
 # Will be called by the image builder for any customisation
@@ -119,7 +122,7 @@ device_image_tweaks() {
 
 # Will be run in chroot (before other things)
 device_chroot_tweaks() {
-#log "Running device_image_tweaks" "ext"
+  #log "Running device_image_tweaks" "ext"
   :
 }
 
@@ -135,10 +138,11 @@ device_chroot_tweaks_pre() {
   dpkg -i linux-image-*_i386.deb
 
   log "Getting the current kernel filename and version"
+  #TODO: Why not just symlink to /boot/vmlinuz
+  # So that initramfs just needs to update that symlink, rather than adjusing boot files each time?
   KRNL=$(ls -l /boot | grep vmlinuz | awk '{print $9}')
-  KVER=$(echo $KRNL | awk -F '-' '{print $2}')
-
-  log "Finished Kernel installation" "okay" "${KRNL}"
+  IFS=- read -ra KVER <<<"$KRNL"
+  log "Finished Kernel ${KVER[1]} installation" "okay" "${KRNL}"
 
   log "Preparing BIOS" "info"
 
@@ -147,9 +151,6 @@ device_chroot_tweaks_pre() {
   syslinux "${BOOT_PART-?BOOT_PART is not known}"
 
   log "Preparing boot configurations" "info"
-
-  log "Creating run-time template for syslinux config"
-  log "Writing cmdline.txt file"
 
   KERNEL_LOGLEVEL="loglevel=0" # Default to KERN_EMERG
   DISABLE_PN="net.ifnames=0"   # For legacy ifnames in buster
@@ -161,9 +162,9 @@ device_chroot_tweaks_pre() {
     # Boot screen stuff
     "splash" "plymouth.ignore-serial-consoles"
     # Output console device and options.
-    "quiet" "console=serial0,115200" "kgdboc=serial0,115200" "console=tty1"
+    "quiet"
     # Boot params
-    "imgpart=UUID=%%IMGPART%%" "bootpart=UUID=%%BOOTPART%%" "datapart=UUID=%%DATAPART%%"
+    "ro" "imgpart=UUID=%%IMGPART%%" "bootpart=UUID=%%BOOTPART%%" "datapart=UUID=%%DATAPART%%"
     # Image params
     "imgfile=/volumio_current.sqsh"
     # Disable linux logo during boot
@@ -181,6 +182,8 @@ device_chroot_tweaks_pre() {
 
   log "Setting ${#kernel_params[@]} Kernel params:" "" "${kernel_params[*]}"
 
+  log "Setting up syslinux and grub configs" "info"
+  log "Creating run-time template for syslinux config"
   # Create a template for init to use later in `update_config_UUIDs`
   cat <<-EOF >/boot/syslinux.tmpl
 	DEFAULT volumio
@@ -191,24 +194,30 @@ device_chroot_tweaks_pre() {
 	INITRD volumio.initrd
 	EOF
 
-  log "Creating syslinux.cfg from template"
+  log "Creating syslinux.cfg from syslinux template"
   cp /boot/syslinux.tmpl /boot/syslinux.cfg
   sed -i "s/%%IMGPART%%/${UUID_IMG}/g" /boot/syslinux.cfg
   sed -i "s/%%BOOTPART%%/${UUID_BOOT}/g" /boot/syslinux.cfg
   sed -i "s/%%DATAPART%%/${UUID_DATA}/g" /boot/syslinux.cfg
 
-  log "Setting up Grub configuration" "info"
-  log "Editing the Grub UEFI config template"
-  log "Using current grub.cfg as run-time template for kernel updates"
-  cp /boot/efi/BOOT/grub.cfg /boot/efi/BOOT/grub.tmpl
+  log "Setting up Grub configuration"
+  grub_tmpl=/boot/efi/BOOT/grub.tmpl
+  grub_cfg=/boot/efi/BOOT/grub.cfg
+  log "Inserting our kernel paramters to grub.tmpl"
+
+  # Use a different delimiter as we might have some `/` paths
+  sed -i "s|%%CMDLINE_LINUX%%|""${kernel_params[*]}""|g" ${grub_tmpl}
+
+  log "Creating grub.cfg from grub template"
+  cp ${grub_tmpl} ${grub_cfg}
 
   log "Inserting root and boot partition UUIDs (building the boot cmdline used in initramfs)"
   # Opting for finding partitions by-UUID
-  sed -i "s/%%IMGPART%%/${UUID_IMG}/g" /boot/efi/BOOT/grub.cfg
-  sed -i "s/%%BOOTPART%%/${UUID_BOOT}/g" /boot/efi/BOOT/grub.cfg
-  sed -i "s/%%DATAPART%%/${UUID_DATA}/g" /boot/efi/BOOT/grub.cfg
-  sed -i "s/%%KVER%%/${KVER}/g" boot/efi/BOOT/grub.cfg
-  sed -i "s/splash quiet loglevel=0/loglevel=8/g" /boot/efi/BOOT/grub.cfg
+  sed -i "s/%%IMGPART%%/${UUID_IMG}/g" ${grub_cfg}
+  sed -i "s/%%BOOTPART%%/${UUID_BOOT}/g" ${grub_cfg}
+  sed -i "s/%%DATAPART%%/${UUID_DATA}/g" ${grub_cfg}
+  sed -i "s/%%KRNL%%/${KRNL}/g" ${grub_cfg}
+  sed -i "s/%%KVER%%/${KVER[1]}/g" ${grub_cfg}
 
   log "Finished setting up boot config" "okay"
 

--- a/scripts/initramfs/init.x86
+++ b/scripts/initramfs/init.x86
@@ -49,7 +49,7 @@ update_config_UUIDs() {
   UUID_DATA=$(blkid -s UUID -o value "${DATAPART}")
   #TODO: Why not just symlink to /boot/vmlinuz
   # So we don't need to update the grub/syslinux with kernel versions?
-  KRNL=$(ls -l /boot | grep vmlinuz | awk '{print $9}')
+  KRNL=$(ls -l ${root_dir} | grep vmlinuz | awk '{print $9}')
   KVER=$(echo "${KRNL}" | awk -F '-' '{print $2}')
 
   mv "${root_dir}"/syslinux.cfg "${root_dir}"/syslinux.cfg.old

--- a/scripts/initramfs/init.x86
+++ b/scripts/initramfs/init.x86
@@ -1,4 +1,5 @@
 #!/bin/busybox sh
+# shellcheck shell=dash
 #
 #
 # Unlike arm devices, an x86 device is much more diverse when it comes to storage devices.
@@ -39,25 +40,34 @@ print_msg() {
 }
 
 update_config_UUIDs() {
-  mkdir /mnt/configs
-  mount -t vfat ${BOOTPART} /mnt/configs
+  local root_dir=/mnt/configs
+  mkdir ${root_dir}
+  mount -t vfat "${BOOTPART}" "${root_dir}"
 
-  UUID_BOOT=$(blkid -s UUID -o value ${BOOTPART})
-  UUID_IMG=$(blkid -s UUID -o value ${IMGPART})
-  UUID_DATA=$(blkid -s UUID -o value ${DATAPART})
+  UUID_BOOT=$(blkid -s UUID -o value "${BOOTPART}")
+  UUID_IMG=$(blkid -s UUID -o value "${IMGPART}")
+  UUID_DATA=$(blkid -s UUID -o value "${DATAPART}")
+  #TODO: Why not just symlink to /boot/vmlinuz
+  # So we don't need to update the grub/syslinux with kernel versions?
+  KRNL=$(ls -l /boot | grep vmlinuz | awk '{print $9}')
+  KVER=$(echo "${KRNL}" | awk -F '-' '{print $2}')
 
-  mv /mnt/configs/syslinux.cfg /mnt/configs/syslinux.cfg.old
-  mv /mnt/configs/syslinux.tmpl /mnt/configs/syslinux.cfg
-  sed -i "s/%%IMGPART%%/${UUID_IMG}/g" /mnt/configs/syslinux.cfg
-  sed -i "s/%%BOOTPART%%/${UUID_BOOT}/g" /mnt/configs/syslinux.cfg
-  sed -i "s/%%DATAPART%%/${UUID_DATA}/g" /mnt/configs/syslinux.cfg
+  mv "${root_dir}"/syslinux.cfg "${root_dir}"/syslinux.cfg.old
+  mv "${root_dir}"/syslinux.tmpl "${root_dir}"/syslinux.cfg
+  sed -i "s/%%IMGPART%%/${UUID_IMG}/g" "${root_dir}"/syslinux.cfg
+  sed -i "s/%%BOOTPART%%/${UUID_BOOT}/g" "${root_dir}"/syslinux.cfg
+  sed -i "s/%%DATAPART%%/${UUID_DATA}/g" "${root_dir}"/syslinux.cfg
+  # Replace the whole line
+  sed -i "/LINUX/c LINUX ${KRNL}" syslinux.tmpl
 
-  mv /mnt/configs/efi/BOOT/grub.cfg /mnt/configs/efi/BOOT/grub.cfg.old
-  mv /mnt/configs/efi/BOOT/grub.tmpl /mnt/configs/efi/BOOT/grub.cfg
-  sed -i "s/root=imgpart=%%IMGPART%%/imgpart=UUID=${UUID_IMG}/g" /mnt/configs/efi/BOOT/grub.cfg
-  sed -i "s/bootpart=%%BOOTPART%%/bootpart=UUID=${UUID_BOOT}/g" /mnt/configs/efi/BOOT/grub.cfg
-  sed -i "s/%%BOOTPART%%/${UUID_BOOT}/g" /mnt/configs/efi/BOOT/grub.cfg
-  sed -i "s/datapart=%%DATAPART%%/datapart=UUID=${UUID_DATA}/g" /mnt/configs/efi/BOOT/grub.cfg
+  mv "${root_dir}"/efi/BOOT/grub.cfg "${root_dir}"/efi/BOOT/grub.cfg.old
+  mv "${root_dir}"/efi/BOOT/grub.tmpl "${root_dir}"/efi/BOOT/grub.cfg
+  sed -i "s/%%IMGPART%%/${UUID_IMG}/g" "${root_dir}"/efi/BOOT/grub.cfg
+  sed -i "s/%%BOOTPART%%/${UUID_BOOT}/g" "${root_dir}"/efi/BOOT/grub.cfg
+  sed -i "s/%%DATAPART%%/${UUID_DATA}/g" "${root_dir}"/efi/BOOT/grub.cfg
+
+  sed -i "s/%%KRNL%%/${KRNL}/g" "${root_dir}"/efi/BOOT/grub.cfg
+  sed -i "s/%%KVER%%/${KVER}/g" "${root_dir}"/efi/BOOT/grub.cfg
 
   sync
   umount /mnt/configs
@@ -165,7 +175,9 @@ if [ $USE_KMSG == no ]; then
 fi
 
 if [ -z "${BOOTPART}" ]; then
-  print_msg "Specify the boot, data and squash image partition on the kernel command ${CMDLINE}"
+  print_msg "Missing BOOTPART"
+  print_msg "Current command: ${CMDLINE}"
+  print_msg "Specify the boot, data and squash image partition on the kernel command"
   print_msg "example: kernel... imgpart=/dev/sda2 bootpart=/dev/sda1 datapart=/dev/sda3 imgfile=/volumio_current.sqs or"
   print_msg "         kernel... imgpart=UUID=b99ad11b-ec63-4a8b-8010-816893807ad6 bootpart=UUID=4A8B-8010 datapart=b44ac11b-eabb-5add-8211-816893807ad6 imgfile=/volumio_current.sqs or"
   print_msg "         kernel... imgpart=LABEL=volumioimg bootpart=LABEL=volumioboot datapart=LABEL=volumiodata imgfile=/volumio_current.sqs"
@@ -174,7 +186,9 @@ if [ -z "${BOOTPART}" ]; then
 fi
 
 if [ -z "${IMGPART}" ]; then
-  print_msg "Specify the boot, data and squash image partition on the kernel command ${CMDLINE}"
+  print_msg "Missing IMGPART"
+  print_msg "Current command: ${CMDLINE}"
+  print_msg "Specify the boot, data and squash image partition on the kernel command"
   print_msg "example: kernel... imgpart=/dev/sda2 bootpart=/dev/sda1 datapart=/dev/sda3 imgfile=/volumio_current.sqs or"
   print_msg "         kernel... imgpart=UUID=b99ad11b-ec63-4a8b-8010-816893807ad6 bootpart=UUID=4A8B-8010 datapart=b44ac11b-eabb-5add-8211-816893807ad6 imgfile=/volumio_current.sqs or"
   print_msg "         kernel... imgpart=LABEL=volumioimg bootpart=LABEL=volumioboot datapart=LABEL=volumiodata imgfile=/volumio_current.sqs"
@@ -183,7 +197,9 @@ if [ -z "${IMGPART}" ]; then
 fi
 
 if [ -z "${DATAPART}" ]; then
-  print_msg "Specify the boot, data and squash image partition on the kernel command ${CMDLINE}"
+  print_msg "Missing DATAPART"
+  print_msg "Current command: ${CMDLINE}"
+  print_msg "Specify the boot, data and squash image partition on the kernel command"
   print_msg "example: kernel... imgpart=/dev/sda2 bootpart=/dev/sda1 datapart=/dev/sda3 imgfile=/volumio_current.sqs or"
   print_msg "         kernel... imgpart=UUID=b99ad11b-ec63-4a8b-8010-816893807ad6 bootpart=UUID=4A8B-8010 datapart=b44ac11b-eabb-5add-8211-816893807ad6 imgfile=/volumio_current.sqs or"
   print_msg "         kernel... imgpart=LABEL=volumioimg bootpart=LABEL=volumioboot datapart=LABEL=volumiodata imgfile=/volumio_current.sqs"
@@ -192,7 +208,9 @@ if [ -z "${DATAPART}" ]; then
 fi
 
 if [ -z "${IMGFILE}" ]; then
-  print_msg "Specify the boot, data and squash image partition on the kernel command ${CMDLINE}"
+  print_msg "Missing IMGFILE"
+  print_msg "Current command: ${CMDLINE}"
+  print_msg "Specify the boot, data and squash image partition on the kernel command"
   print_msg "example: kernel... imgpart=/dev/sda2 bootpart=/dev/sda1 datapart=/dev/sda3 imgfile=/volumio_current.sqs or"
   print_msg "         kernel... imgpart=UUID=b99ad11b-ec63-4a8b-8010-816893807ad6 bootpart=UUID=4A8B-8010 datapart=b44ac11b-eabb-5add-8211-816893807ad6 imgfile=/volumio_current.sqs or"
   print_msg "         kernel... imgpart=LABEL=volumioimg bootpart=LABEL=volumioboot datapart=LABEL=volumiodata imgfile=/volumio_current.sqs"

--- a/scripts/makeimage.sh
+++ b/scripts/makeimage.sh
@@ -35,6 +35,7 @@ parted -s "${LOOP_DEV}" mkpart primary fat32 "${BOOT_START:-0}" "${BOOT_END}"
 parted -s "${LOOP_DEV}" mkpart primary ext3 "${BOOT_END}" 2500
 parted -s "${LOOP_DEV}" mkpart primary ext3 2500 100%
 parted -s "${LOOP_DEV}" set 1 boot on
+[[ "${BOOT_TYPE}" == gpt ]] && parted -s "${LOOP_DEV}" set 1 legacy_boot on # for non UEFI systems
 parted -s "${LOOP_DEV}" print
 partprobe "${LOOP_DEV}"
 kpartx -a "${LOOP_DEV}" -s

--- a/scripts/makeimage.sh
+++ b/scripts/makeimage.sh
@@ -155,7 +155,9 @@ fi
 # Copy across custom bits and bobs from device config
 # This is in the hope that <./recipes/boards/${DEVICE}>
 # doesn't grow back into the old <xxxxconfig.sh>
-
+BOOT_FS_SPEC="/dev/mmcblk0p1"
+[[ ${BOOT_USE_UUID} == yes ]] && BOOT_FS_SPEC="UUID=${UUID_BOOT}"
+log "Setting /boot fs_sepc to ${BOOT_FS_SPEC}"
 #TODO: Should we just copy the
 # whole thing into the chroot to make life easier?
 cat <<-EOF >$ROOTFSMNT/chroot_device_config.sh
@@ -165,6 +167,7 @@ BUILD="${BUILD}"
 DEBUG_IMAGE="${DEBUG_IMAGE:-no}"
 KIOSKMODE="${KIOSKMODE:-no}"
 VOLVARIANT="${VOLVARIANT:-volumio}"
+BOOT_FS_SPEC=${BOOT_FS_SPEC}
 UUID_BOOT=${UUID_BOOT}
 UUID_IMG=${UUID_IMG}
 UUID_DATA=${UUID_DATA}

--- a/scripts/volumio/chrootconfig.sh
+++ b/scripts/volumio/chrootconfig.sh
@@ -24,21 +24,17 @@ log "Running final config for ${DEVICENAME}"
 
 ## Setup Fstab
 log "Creating fstab" "info"
-# TODO: Can't we make this simpler and just and just sed out the /dev/mmcblk0p1 to %%BOOTPART
-# Instead of copying a seperate file just for that?
-if [[ ! $BUILD == x86 ]]; then
-  cat <<-EOF >/etc/fstab
-	# ${DEVICENAME} fstab
-	
-	proc           /proc                proc    defaults                                  0 0
-	/dev/mmcblk0p1 /boot                vfat    defaults,utf8,user,rw,umask=111,dmask=000 0 1
-	tmpfs          /var/log             tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4,  0 0
-	tmpfs          /var/spool/cups      tmpfs   defaults,noatime,mode=0755                0 0
-	tmpfs          /var/spool/cups/tmp  tmpfs   defaults,noatime,mode=0755                0 0
-	tmpfs          /tmp                 tmpfs   defaults,noatime,mode=0755                0 0
-	tmpfs          /dev/shm             tmpfs   defaults,nosuid,noexec,nodev              0 0
-	EOF
-fi
+cat <<-EOF >/etc/fstab
+# ${DEVICENAME} fstab
+
+proc            /proc                proc    defaults                                  0 0
+${BOOT_FS_SPEC} /boot                vfat    defaults,utf8,user,rw,umask=111,dmask=000 0 1
+tmpfs           /var/log             tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4,  0 0
+tmpfs           /var/spool/cups      tmpfs   defaults,noatime,mode=0755                0 0
+tmpfs           /var/spool/cups/tmp  tmpfs   defaults,noatime,mode=0755                0 0
+tmpfs           /tmp                 tmpfs   defaults,noatime,mode=0755                0 0
+tmpfs           /dev/shm             tmpfs   defaults,nosuid,noexec,nodev              0 0
+EOF
 
 ## Initial chroot config
 declare -fF device_chroot_tweaks &>/dev/null &&

--- a/scripts/volumio/configure.sh
+++ b/scripts/volumio/configure.sh
@@ -28,8 +28,6 @@ if [[ $BUILD == x86 ]]; then
   #Grub2 conf file
   cp "${SRC}/volumio/etc/default/grub" "${ROOTFS}/etc/default/grub"
   cp "${SRC}/volumio/splash/volumio.png" "${ROOTFS}/boot"
-  #FSTAB File
-  cp "${SRC}/volumio/etc/fstab.x86" "${ROOTFS}/etc/fstab"
 else
   log 'Setting time for ARM devices with fakehwclock to build time'
   date -u '+%Y-%m-%d %H:%M:%S' >"${ROOTFS}/etc/fake-hwclock.data"

--- a/scripts/volumio/finalize.sh
+++ b/scripts/volumio/finalize.sh
@@ -29,24 +29,24 @@ if [[ $BUILD != "x86" ]]; then
   log "Cleaning man and caches"
   rm -rf ${ROOTFSMNT}/usr/share/man/* ${ROOTFSMNT}/usr/share/groff/* ${ROOTFSMNT}/usr/share/info/*
   rm -rf ${ROOTFSMNT}/usr/share/lintian/* ${ROOTFSMNT}/usr/share/linda/* ${ROOTFSMNT}/var/cache/man/*
+
+  #TODO: This doesn't seem to be doing much atm
+  log "Stripping binaries"
+  STRP_DIRECTORIES=("${ROOTFSMNT}/lib/"
+    "${ROOTFSMNT}/bin/"
+    "${ROOTFSMNT}/usr/sbin"
+    "${ROOTFSMNT}/usr/local/bin/")
+
+  for DIR in "${STRP_DIRECTORIES[@]}"; do
+    log "$DIR Pre strip size " "$(du -sh0 "$DIR" | awk '{print $1}')"
+    find "$DIR" -type f -exec strip --strip-all {} ';' >/dev/null 2>&1
+    log "$DIR Post strip size " "$(du -sh0 "$DIR" | awk '{print $1}')"
+  done
 else
-  echo "X86 environment detected, not cleaning"
+  log "x86 environment detected, not cleaning/stripping libs"
 fi
 
 # Got to do this here to make it stick
 log "Updating MOTD"
 rm -f ${ROOTFSMNT}/etc/motd ${ROOTFSMNT}/etc/update-motd.d/*
 cp "${SRC}"/volumio/etc/update-motd.d/* ${ROOTFSMNT}/etc/update-motd.d/
-
-#TODO: This doesn't seem to be doing much atm
-log "Stripping binaries"
-STRP_DIRECTORIES=("${ROOTFSMNT}/lib/"
-  "${ROOTFSMNT}/bin/"
-  "${ROOTFSMNT}/usr/sbin"
-  "${ROOTFSMNT}/usr/local/bin/")
-
-for DIR in "${STRP_DIRECTORIES[@]}"; do
-  log "$DIR Pre strip size " "$(du -sh0 "$DIR" | awk '{print $1}')"
-  find "$DIR" -type f -exec strip --strip-all {} ';' >/dev/null 2>&1
-  log "$DIR Post strip size " "$(du -sh0 "$DIR" | awk '{print $1}')"
-done


### PR DESCRIPTION
Tested with UEFI and seems to boot :-) 
Don't have a legacy boot device to test though. 

@gkkpch while looking at the diff, I realise that the kernel version parsing in the init script will not work. It's still points to `/boot`. I will fix that, but can't we just symlink ` /boot/vmlinuz` to the current version so that we don't need to parse and insert kernel versions into the grub/syslinux config?

N.B: I do get some errors w.t.r `Alternate GPT header not at the end of the disk.` on the first run of `initramfs`. A cursory search seems to suggest that we can't [fix this during image creation?](https://hub.mender.io/t/gpt-primary-header-thinks-alt-header-is-not-at-the-end-of-the-disk/2094)

>This is only true if the “offline” image is the exact same size as the storage medium size.
>GPT alternative headers are relative to the storage medium size, e.g they are at block position -1.
>So you need to run sgdisk -e or echo 'w' | fdisk /dev/mmcblk0 or similar on your device once to make >sure the alternative GPT headers are written to the correct location.
